### PR TITLE
/scan/start wrongly defines "url"

### DIFF
--- a/Documentation/api/swagger/swagger.yaml
+++ b/Documentation/api/swagger/swagger.yaml
@@ -35,9 +35,9 @@ paths:
           schema: 
             type: object
             required:
-            - url
+            - domain
             properties:
-              url:
+              domain:
                 type: string
               dangerLevel:
                 type: integer


### PR DESCRIPTION
/scan/start defines "url" but implementation expects "domain"