### PR TITLE
Bugfix/accept 3xx

### DIFF
--- a/app/Http/Controllers/ScanController.php
+++ b/app/Http/Controllers/ScanController.php
@@ -149,7 +149,7 @@ class ScanController extends Controller
 
         try {
             $response = $client->get($domain);
-            if ($response->getStatusCode() === 200 || floor($response->getStatusCode() / 100) === 3 ) {
+            if ($response->getStatusCode() === 200 || floor($response->getStatusCode() / 100) === 3) {
                 return true;
             }
         } catch (\Exception $ex) {

--- a/app/Http/Controllers/ScanController.php
+++ b/app/Http/Controllers/ScanController.php
@@ -149,7 +149,7 @@ class ScanController extends Controller
 
         try {
             $response = $client->get($domain);
-            if ($response->getStatusCode() === 200 || $response->getStatusCode() === 301) {
+            if ($response->getStatusCode() === 200 || floor($response->getStatusCode() / 100) === 3 ) {
                 return true;
             }
         } catch (\Exception $ex) {


### PR DESCRIPTION
Dies sollte das Problem beheben, dass es durchaus auch andere redirects als nur 301 verwendet werden.

Die Frage ist, ob wir dem Benutzer den error code anzeigen sollten, wenn die Domain nicht mit 200 oder 3xx antwortet…