### PR TITLE
Callback URL für Siegelgenerierung.

### DIFF
--- a/app/Console/Commands/DailyScan.php
+++ b/app/Console/Commands/DailyScan.php
@@ -72,7 +72,7 @@ QUERY
             $bar = $this->output->createProgressBar($max_schedule);
             // If RECURRENT_PER_RUN is defined and > 0 this many scans are started per run
             foreach ($domains as $domain) {
-                ScanController::startScanJob($domain->domain, true, 10);
+                ScanController::startScanJob($domain->domain, true, 10, [ env('APP_CALLBACK_URL') ]);
                 $this->info('Scan started for: '.$domain->domain);
                 $bar->advance();
                 // no more scans are allowed to be started

--- a/app/Console/Commands/DailyScan.php
+++ b/app/Console/Commands/DailyScan.php
@@ -72,7 +72,7 @@ QUERY
             $bar = $this->output->createProgressBar($max_schedule);
             // If RECURRENT_PER_RUN is defined and > 0 this many scans are started per run
             foreach ($domains as $domain) {
-                ScanController::startScanJob($domain->domain, true, 10, [ env('APP_CALLBACK_URL') ]);
+                ScanController::startScanJob($domain->domain, true, 10, [ 'https://bla.siwecos.de/api/v1/scan/finished' ]);
                 $this->info('Scan started for: '.$domain->domain);
                 $bar->advance();
                 // no more scans are allowed to be started


### PR DESCRIPTION
Achtung:
Dieser Teil der Daily Scans muss in die BLA verschoben werden.

Dies ist Teil von https://github.com/SIWECOS/siwecos-business-layer/issues/83 und wird bald ohnehin geändert. Um jetzt die Siegel-Generierung auf GCS abzuschließen bzw. funktionsfähig zu machen, sollte diese Änderung erstmal ausreichen.