### PR TITLE
Fix HTTP 500 bei /scan/finished Callback zur BLA

### DIFF
--- a/app/Http/Controllers/ScanController.php
+++ b/app/Http/Controllers/ScanController.php
@@ -222,23 +222,9 @@ class ScanController extends Controller
 
             $client = new Client([
                 'headers' => ['User-Agent' => config('app.userAgent')],
-                'timeout' => 5,
             ]);
 
-            /**
-             * TODO: Entfernen
-             * - Die Domain-Notification hat nichts in der CORE-API zu suchen!
-             * - Die Implementierung muss in der BLA erfolgen
-             * Siehe https://github.com/SIWECOS/siwecos-business-layer/issues/83
-             */
-            $domain = Domain::whereDomain($scan->url)->first();
-            if ($domain instanceof Domain && ($domain->last_notification === null || $domain->last_notification < Carbon::now()->addWeeks(-1))) {
-                $domain->last_notification = Carbon::now();
-                $domain->save();
-            }
-
             foreach ($scan->callbackurls as $callbackURL) {
-                // TODO: Make this async
                 $client->post($callbackURL, [
                     'json' => [
                         'scanId' => $scan->id,


### PR DESCRIPTION
Problem:
Es traten viele 500er Fehler ohne weitere Beschreibung beim `/api/v1/scan/finished` Endpunkt der BLA auf.

Fix:
Der Timeout war anscheinend zu kurz gewählt, sodass die CA nicht den kompletten Request an die BLA senden konnte.
Timeout-Option wurde entfernt, um den Standard-Timeout von Guzzle zu verwenden.

Fixed ebenfalls https://github.com/SIWECOS/siwecos-business-layer/issues/101