### PR TITLE
[HOTFIX] ScanStart Fire&Forget

### DIFF
--- a/app/Jobs/ScanJob.php
+++ b/app/Jobs/ScanJob.php
@@ -67,5 +67,7 @@ class ScanJob implements ShouldQueue
         ]));
 
         $client->sendAsync($request, ['timeout' => 2.0]);
+
+        Log::info('Fire&Forget ScanStart for ' . $this->name . ' (' . $scanResult->scan_id . ')');
     }
 }

--- a/app/Jobs/ScanJob.php
+++ b/app/Jobs/ScanJob.php
@@ -66,37 +66,6 @@ class ScanJob implements ShouldQueue
             'userAgent'    => config('app.userAgent'),
         ]));
 
-        $response = $client->sendAsync($request);
-
-        try {
-            /** @var Response $promise */
-            $promise = $response->wait();
-            $status = $promise->getStatusCode();
-            Log::info('StatusCode for ' . $this->name . ' (' . $scanResult->scan_id . '): ' . $status);
-            if ($status !== 200) {
-                $scanResult->result = self::getErrorArray($this->name, $status);
-            }
-        } catch (Exception $ex) {
-            $scanResult->result = self::getErrorArray($this->name, 500, $ex->getMessage());
-        }
-    }
-
-    public static function getErrorArray(string $scanner, int $status, string $exception = '')
-    {
-        $timeout = [];
-        $timeout['name'] = 'SCANNER_ERROR';
-        $timeout['hasError'] = true;
-        $timeout['dangerlevel'] = 0;
-        $timeout['score'] = 0;
-        $timeout['scoreType'] = 'success';
-        $timeout['testDetails'] = [];
-        $timeout['errorMessage'] = [];
-        $timeout['errorMessage']['placeholder'] = 'SCANNER_ERROR';
-        $timeout['errorMessage']['values'] = [];
-        $timeout['errorMessage']['values']['scanner'] = $scanner;
-        $timeout['errorMessage']['values']['statuscode'] = $status;
-        $timeout['errorMessage']['values']['exception'] = $status;
-
-        return [$timeout];
+        $client->sendAsync($request, ['timeout' => 2.0]);
     }
 }


### PR DESCRIPTION
Startet die Scanner ohne auf Antwort zu warten.

Umgeht das momentane Problem mit dem InfoLeak Scanner.

Alle anderen Scanner sollten ohnehin nicht in einen Timeout laufen.
Darüberhinaus gibt es Möglichkeiten um Probleme beim TLS bspw. zu erkennen.