### PR TITLE
Hotfix: ErrorArray speichern

### DIFF
--- a/app/Jobs/ScanJob.php
+++ b/app/Jobs/ScanJob.php
@@ -75,9 +75,11 @@ class ScanJob implements ShouldQueue
             Log::info('StatusCode for ' . $this->name . ' (' . $scanResult->scan_id . '): ' . $status);
             if ($status !== 200) {
                 $scanResult->result = self::getErrorArray($this->name, $status);
+                $scanResult->save();
             }
         } catch (Exception $ex) {
             $scanResult->result = self::getErrorArray($this->name, 500, $ex->getMessage());
+            $scanResult->save();
         }
     }
 


### PR DESCRIPTION
Kann ein Scanner nicht gestartet werden, muss das `errorArray` auch gespeichert werden.

Bisher wurde der Wert nur zugewiesen.